### PR TITLE
Updated pyproject toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
-pytest = "^8.3.3"
+pytest = "^8.3.5"
 anypubsub = "^0.6"
 
 # This will bring in volttron-core, lib-zmq and lib-auth by default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,5 +71,5 @@ warn_return_any = true
 warn_unused_configs = true
 
 [build-system]
-requires = ["poetry-core>=1.2.0"]
+requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Pytest has been updated to a more recent version

poetry-core is now using 2.0.0 instead of 1.2.0